### PR TITLE
Added storage_max_events option, updated pg_storage event loading

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -51,7 +51,8 @@ class Flower(tornado.web.Application):
             io_loop=self.io_loop,
             max_workers_in_memory=self.options.max_workers,
             max_tasks_in_memory=self.options.max_tasks,
-            storage_driver=self.options.storage_driver)
+            storage_driver=self.options.storage_driver,
+            storage_max_events=self.options.storage_max_events)
         self.started = False
 
     def start(self):

--- a/flower/app.py
+++ b/flower/app.py
@@ -42,6 +42,7 @@ class Flower(tornado.web.Application):
                 self.options.pg_port,
                 self.options.pg_ssl,
             )
+            pg_storage.maybe_create_schema()
 
         self.capp = capp or celery.Celery()
         self.events = events or Events(

--- a/flower/events.py
+++ b/flower/events.py
@@ -57,7 +57,7 @@ class Events(threading.Thread):
 
     def __init__(self, capp, db=None, persistent=False,
                  enable_events=True, io_loop=None, storage_driver=None,
-                 **kwargs):
+                 storage_max_events=None, **kwargs):
         threading.Thread.__init__(self)
         self.daemon = True
 
@@ -67,6 +67,7 @@ class Events(threading.Thread):
         self.db = db
         self.persistent = persistent
         self.storage_driver = storage_driver
+        self.storage_max_events = storage_max_events
         self.enable_events = enable_events
         self.state = None
 
@@ -94,8 +95,9 @@ class Events(threading.Thread):
                 # because the callable is cached in the closure of
                 # celery.events.state.State._create_dispatcher
                 pg_storage.skip_callback = True
+
                 try:
-                    for event in pg_storage.get_all_events():
+                    for event in pg_storage.get_events(max_events=self.storage_max_events):
                         self.state.event(event, websockets=False)
                 finally:
                     pg_storage.skip_callback = False

--- a/flower/events.py
+++ b/flower/events.py
@@ -56,8 +56,8 @@ class Events(threading.Thread):
     events_enable_interval = 5000
 
     def __init__(self, capp, db=None, persistent=False,
-                 enable_events=True, io_loop=None, storage_driver=None,
-                 storage_max_events=None, **kwargs):
+                 enable_events=True, io_loop=None, max_tasks_in_memory=None,
+                 storage_driver=None, storage_max_events=None, **kwargs):
         threading.Thread.__init__(self)
         self.daemon = True
 
@@ -68,6 +68,7 @@ class Events(threading.Thread):
         self.persistent = persistent
         self.storage_driver = storage_driver
         self.storage_max_events = storage_max_events
+        self.max_tasks_in_memory = max_tasks_in_memory
         self.enable_events = enable_events
         self.state = None
 
@@ -97,7 +98,8 @@ class Events(threading.Thread):
                 pg_storage.skip_callback = True
 
                 try:
-                    for event in pg_storage.get_events(max_events=self.storage_max_events):
+                    for event in pg_storage.get_events(max_events=self.storage_max_events,
+                                                       max_tasks=self.max_tasks_in_memory):
                         self.state.event(event, websockets=False)
                 finally:
                     pg_storage.skip_callback = False

--- a/flower/options.py
+++ b/flower/options.py
@@ -67,8 +67,8 @@ define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
 define("url_prefix", type=str, help="base url prefix")
 define("storage_driver", type=str, default="file",
        help='Which driver to use for storing events ("file" or "postgres")')
-define("storage_max_events", type=int, default=30000,
-       help="Max events to load from persistence store")
+define("storage_max_events", type=int, default=None,
+       help="Max events to load from persistence store. Default is disabled (use max_tasks), -1 will load all events")
 define("pg_user", type=str, help="Postgres user name")
 define("pg_pass", type=str, help="Postgres user password")
 define("pg_database", type=str, default="flower_events",

--- a/flower/options.py
+++ b/flower/options.py
@@ -67,6 +67,8 @@ define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
 define("url_prefix", type=str, help="base url prefix")
 define("storage_driver", type=str, default="file",
        help='Which driver to use for storing events ("file" or "postgres")')
+define("storage_max_events", type=int, default=30000,
+       help="Max events to load from persistence store")
 define("pg_user", type=str, help="Postgres user name")
 define("pg_pass", type=str, help="Postgres user password")
 define("pg_database", type=str, default="flower_events",
@@ -75,6 +77,7 @@ define("pg_host", type=str, default="localhost", help="Postgres host name")
 define("pg_port", type=int, default=5432, help="Postgres server port")
 define("pg_ssl", type=bool, default=False,
        help="Use SSL encryption for Postgres connection")
+
 
 
 # deprecated options

--- a/flower/utils/pg_storage.py
+++ b/flower/utils/pg_storage.py
@@ -138,7 +138,6 @@ def close_connection():
 def get_events(max_events, max_tasks):
     logger.debug('Events loading from postgresql persistence backend')
     cursor = connection.cursor()
-    retries_remaining = REQ_MAX_RETRIES
     for attempt in range(0, REQ_MAX_RETRIES):
         try:
             if max_events:

--- a/flower/utils/pg_storage.py
+++ b/flower/utils/pg_storage.py
@@ -150,7 +150,7 @@ def get_events(max_events, max_tasks):
                 query = _get_task_events.format(max_tasks=max_tasks)
             cursor.execute(query)
             for row in cursor:
-                yield row[0]
+                yield json.loads(row[0])
             logger.debug('{} Events loaded from postgresql persistence backend'.format(cursor.rowcount))
         except (socketerror, pg8000.InterfaceError):
             if attempt < REQ_MAX_RETRIES:

--- a/flower/utils/pg_storage.py
+++ b/flower/utils/pg_storage.py
@@ -1,12 +1,16 @@
 import json
 import logging
 from datetime import datetime
+from socket import error as socketerror
 
 import pg8000
 
 logger = logging.getLogger(__name__)
 connection = None
+_connection_options = {}
 skip_callback = False
+
+REQ_MAX_RETRIES = 2
 
 _all_tables = """
 SELECT * FROM information_schema.tables
@@ -19,7 +23,7 @@ _schema = (
         id SERIAL PRIMARY KEY,
         time TIMESTAMP NOT NULL,
         uuid VARCHAR(36) NOT NULL,
-        data JSONB NOT NULL,
+        data TEXT NOT NULL,
         unique (time, data)
     )""",
     "CREATE INDEX event_time_index ON events (time ASC)",
@@ -65,27 +69,49 @@ def event_callback(state, event):
         return
 
     cursor = connection.cursor()
-    try:
-        cursor.execute(_add_event, (
-            datetime.fromtimestamp(event['timestamp']),
-            event['uuid'],
-            json.dumps(event)
-        ))
-        connection.commit()
-    except Exception:
-        connection.rollback()
-        raise
-    finally:
-        cursor.close()
+    for attempt in range(0, REQ_MAX_RETRIES):
+        try:
+            cursor.execute(_add_event, (
+                datetime.fromtimestamp(event['timestamp']),
+                event['uuid'],
+                json.dumps(event)
+            ))
+            connection.commit()
+            logger.debug('Added event {} to PostGreSQL persistence store'.format(event['uuid']))
+        except (socketerror, pg8000.InterfaceError):
+            if attempt < REQ_MAX_RETRIES:
+                logger.warning('Flower encountered a connection error with PostGreSQL database. Retrying.')
+                open_connection(**_connection_options)
+                cursor = connection.cursor()
+                continue
+            else:
+                logger.exception('Flower encountered a connection error with PostGreSQL database. Unable to retry.')
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            cursor.close()
+            return
 
 
 def open_connection(user, password, database, host, port, use_ssl):
     global connection
+    global _connection_options
     connection = pg8000.connect(
         user=user, password=password, database=database,
         host=host, port=port, ssl=use_ssl
     )
+    _connection_options = {'user': user,
+                           'password': password,
+                           'database': database,
+                           'host': host,
+                           'port': port,
+                           'use_ssl': use_ssl
+                           }
 
+
+def maybe_create_schema():
+    global connection
     # Create schema if table is missing
     cursor = connection.cursor()
     try:
@@ -112,17 +138,28 @@ def close_connection():
 def get_events(max_events, max_tasks):
     logger.debug('Events loading from postgresql persistence backend')
     cursor = connection.cursor()
-    try:
-        if max_events:
-            if max_events == -1:
-                query = _get_max_events.format(max_events='ALL')
+    retries_remaining = REQ_MAX_RETRIES
+    for attempt in range(0, REQ_MAX_RETRIES):
+        try:
+            if max_events:
+                if max_events == -1:
+                    query = _get_max_events.format(max_events='ALL')
+                else:
+                    query = _get_max_events.format(max_events=max_events)
             else:
-                query = _get_max_events.format(max_events=max_events)
-        else:
-            query = _get_task_events.format(max_tasks=max_tasks)
-        cursor.execute(query)
-        for row in cursor:
-            yield row[0]
-        logger.debug('{} Events loaded from postgresql persistence backend'.format(cursor.rowcount))
-    finally:
-        cursor.close()
+                query = _get_task_events.format(max_tasks=max_tasks)
+            cursor.execute(query)
+            for row in cursor:
+                yield row[0]
+            logger.debug('{} Events loaded from postgresql persistence backend'.format(cursor.rowcount))
+        except (socketerror, pg8000.InterfaceError):
+            if attempt < REQ_MAX_RETRIES:
+                logger.warning('Flower encountered a connection error with PostGreSQL database. Retrying.')
+                open_connection(**_connection_options)
+                cursor = connection.cursor()
+                continue
+            else:
+                logger.exception('Flower encountered a connection error with PostGreSQL database. Unable to retry.')
+        finally:
+            cursor.close()
+            return


### PR DESCRIPTION
This option allows limiting the max number of events loaded from the storage provider (i.e. postgresql).  Thus, loading performance will be deterministic regardless of how big the table gets.